### PR TITLE
Add darwin/arm64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     - windows
     - darwin
     goarch:
+    - arm64
     - amd64
     - "386"
     env:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL := bash
 .DEFAULT_GOAL := help
 
 export GO111MODULE ?= on
-export GOARCH      ?= amd64
+export GOARCH      ?= arm64
 export CGO_ENABLED ?= 0
 
 PROJECT   ?= pod-dive
@@ -34,7 +34,7 @@ GOOS      ?= $(shell go env GOOS)
 GOPATH    ?= $(shell go env GOPATH)
 
 BUILDDIR  := out
-PLATFORMS ?= darwin/amd64 windows/amd64 linux/amd64
+PLATFORMS ?= darwin/arm64 darwin/amd64 windows/amd64 linux/amd64
 DISTFILE  := $(BUILDDIR)/$(VERSION).tar.gz
 ASSETS     := $(BUILDDIR)/pod-dive-$(GOARCH)-darwin.tar.gz $(BUILDDIR)/pod-dive-$(GOARCH)-linux.tar.gz $(BUILDDIR)/pod-dive-$(GOARCH)-windows.zip
 CHECKSUMS  := $(patsubst %,%.sha256,$(ASSETS))
@@ -128,6 +128,7 @@ dist: $(DISTFILE) ## create a tar archive of the source code
 compact: build
 	@cp LICENSE $(BUILDDIR) && \
 	cd $(BUILDDIR) && \
+	tar cvvfz pod-dive-arm64-darwin.tar.gz pod-dive-arm64-darwin LICENSE && \
 	tar cvvfz pod-dive-amd64-darwin.tar.gz pod-dive-amd64-darwin LICENSE && \
 	tar cvvfz pod-dive-amd64-linux.tar.gz pod-dive-amd64-linux LICENSE && \
 	zip pod-dive-amd64-windows.exe.zip pod-dive-amd64-windows.exe LICENSE
@@ -150,7 +151,9 @@ endif
 
 .PHONE: install
 install: build
-	sudo cp -vaf out/pod-dive-amd64-$(THIS_OS) $(HOME)/.krew/bin/kubectl-pod_dive
+	mkdir -p $(HOME)/.krew/store/pod-dive/$(VERSION) && \
+	cp -va out/pod-dive-$(GOARCH)-$(THIS_OS) $(HOME)/.krew/store/pod-dive/$(VERSION)/kubectl-pod_dive && \
+	ln -s $(HOME)/.krew/store/pod-dive/$(VERSION)/kubectl-pod_dive $(HOME)/.krew/bin/kubectl-pod_dive
 
 .PHONY: clean
 clean: ## clean up build directory and binaries files
@@ -158,4 +161,5 @@ clean: ## clean up build directory and binaries files
 
 $(BUILDDIR)/pod-dive-amd64-linux: build
 $(BUILDDIR)/pod-dive-amd64-darwin: build
+$(BUILDDIR)/pod-dive-arm64-darwin: build
 $(BUILDDIR)/pod-dive-amd64-windows.exe: build

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ A `kubectl` [Krew](https://krew.dev) plugin to dive into your Kubernetes nodes p
 
 Icon art made by [Smashicons](https://www.flaticon.com/authors/smashicons) from [Flaticon](https://www.flaticon.com/). [We had one before Krew itself](https://github.com/kubernetes-sigs/krew/issues/437), go figure.
 
+
+## About this fork
+
+This repository is a fork of [caiobegotti/Pod-Dive](https://github.com/caiobegotti/Pod-Dive). It seems the original project is not being maintained for a while but I found this tool useful for some scenarios.
+Please, do not expect any kind of support for this forked repository.
+
 ## Quick Start
 
-If you don't use Krew to manage `kubectl` plugins [you can simply download the binary here](https://github.com/caiobegotti/Pod-Dive/releases) and put it in your PATH.
+If you don't use Krew to manage `kubectl` plugins [you can simply download the binary here](https://github.com/fsan/Pod-Dive/releases) and put it in your PATH.
 
 ```
 kubectl krew install pod-dive

--- a/deploy/krew/plugin.yaml
+++ b/deploy/krew/plugin.yaml
@@ -1,16 +1,19 @@
+# out/pod-dive-amd64-windows.exe
+# out/pod-dive-arm64-darwin
+
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: pod-dive
 spec:
-  version: "v0.1.4"
+  version: "v0.1.6"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.4/pod-dive-amd64-linux.tar.gz
-    sha256: "663d7f981b3c01dc13bfc2119b0abd0b5b20c85b4b755f6fec9e8cb8be34f343"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.6/pod-dive-amd64-linux.tar.gz
+    sha256: "1b1b0c05a3e24315c13f97f20b33890e722bb0daa6efa5403826f3dd201a2d4b"
     files:
     - from: "./LICENSE"
       to: "."
@@ -20,9 +23,21 @@ spec:
   - selector:
       matchLabels:
         os: darwin
+        arch: arm64
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.6/pod-dive-arm64-darwin.tar.gz
+    sha256: "1cfae45695dc9489fa7ce4d938a84ee5ec75f72e3bf3717ab543cefed55d3a17"
+    files:
+    - from: "./LICENSE"
+      to: "."
+    - from: "./pod-dive-arm64-darwin"
+      to: "."
+    bin: "pod-dive-arm64-darwin"
+  - selector:
+      matchLabels:
+        os: darwin
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.4/pod-dive-amd64-darwin.tar.gz
-    sha256: "d314e57e5807afc4669c5a25852a733f1bc3140441bbd397b5666b22b5090617"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.6/pod-dive-amd64-darwin.tar.gz
+    sha256: "89be29e4f29f84fb3e3258f8d7658261914ae6f5ae10c8862f3de83210a99bb6"
     files:
     - from: "./LICENSE"
       to: "."
@@ -33,8 +48,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.4/pod-dive-amd64-windows.exe.zip
-    sha256: "199481b1a5caffe419cf7d2972f19043655ace20ca79394784636e98693b1540"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.6/pod-dive-amd64-windows.exe.zip
+    sha256: "aab563338aa3ccfc3839218d7ce3c7689b0a48d515a1e30a52a101eecc3752a1"
     files:
     - from: "./LICENSE"
       to: "."


### PR DESCRIPTION
I believe this project is not being maintained at the moment, but I am adding a simple patch to include the build support for darwin/arm64.

I forked the project [here](https://github.com/fsan/Pod-Dive) and the binaries are available on the release page.

The repo owner may want to remove the changes I made to README.md before merging.